### PR TITLE
[fix] github desktop환경에서 commitlint경로를 찾지 못하는 오류 해결

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit "$1"
+./node_modules/.bin/commitlint --edit "$1"


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : github desktop환경에서 commitlint경로를 찾지 못하는 오류 해결
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- github desktop에서 commitlint의 경로를 찾을 수 없어 commit 오류가 나던 부분 해결

### 작업 내역

- commit-msg파일에서 commitlint의 경로를 node_modules하위로 명확하게 설정

### 작업 후 기대 동작(스크린샷)

- github desktop환경에서도 commitlint정상 작동

### PR 특이 사항

- 없음

### Issue Number 

close: #5 
